### PR TITLE
remove EVP_sha() from openssl algorithms. Bump nan to latest 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,67 @@
+{
+    "name": "node-openssl-verify-cert",
+    "version": "0.9.9",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "nan": {
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+            "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+        },
+        "should": {
+            "version": "11.2.1",
+            "resolved": "https://registry.npmjs.org/should/-/should-11.2.1.tgz",
+            "integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
+            "dev": true,
+            "requires": {
+                "should-equal": "^1.0.0",
+                "should-format": "^3.0.2",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
+            }
+        },
+        "should-equal": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
+            "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
+            "dev": true,
+            "requires": {
+                "should-type": "^1.0.0"
+            }
+        },
+        "should-format": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+            "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+            "dev": true,
+            "requires": {
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
+            }
+        },
+        "should-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+            "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+            "dev": true
+        },
+        "should-type-adaptors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+            "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+            "dev": true,
+            "requires": {
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
+            }
+        },
+        "should-util": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+            "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -10,14 +10,18 @@
     "scripts": {
         "test": "mocha"
     },
-    "keywords": ["OpenSSL", "verify", "certificate"],
+    "keywords": [
+        "OpenSSL",
+        "verify",
+        "certificate"
+    ],
     "author": "Beeven Yip <beeven@hotmail.com>",
     "contributors": [
         "tmyersjstar"
     ],
     "license": "MIT",
     "dependencies": {
-        "nan": "^2.4.0"
+        "nan": "2.11.1"
     },
     "devDependencies": {
         "should": "^11.1.1"

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -28,7 +28,6 @@ void VerifyCert(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     v8::Local<v8::Function> cb = info[2].As<v8::Function>();
 
     //OpenSSL_add_all_algorithms();
-    EVP_add_digest(EVP_sha());
     EVP_add_digest(EVP_sha1());
     EVP_add_digest(EVP_sha224());
     EVP_add_digest(EVP_sha256());


### PR DESCRIPTION
and force versioning.

## Makes package being able to build with node v > 10.

I believe the function call to `EVP_add_digest(EVP_sha());` has never existed or has laster been removed from _openssl_. At least it is not available anymore, when trying to compile with node version **10.12.0**. 

https://github.com/openssl/openssl/blob/master/crypto/evp/c_alld.c

**Tests are failing.**

I suspect this **solely** to be because of long living certificates that is now **expired** - as tests on master haven't been run for more than **two years**. :) 

I am not going to dig into fixing tests in this project, as the tests in the project with use this package pass. 

Leaving PR open for anyone that might meet problems when upgrading node version. 